### PR TITLE
Fix potential issues

### DIFF
--- a/header/toml-c.h
+++ b/header/toml-c.h
@@ -89,7 +89,7 @@ struct toml_timestamp_t {
 	char kind;
 	int year, month, day;
 	int hour, minute, second, millisec;
-	char *z;
+	char z[10];
 };
 
 // toml_parse() parses a TOML document from a string. Returns 0 on error, with
@@ -1808,8 +1808,7 @@ int toml_value_timestamp(toml_unparsed_t src_, toml_timestamp_t *ret) {
 
 		if (*p) { /// parse and copy Z
 			ret->kind = 'd';
-			char *z = malloc(10);
-			ret->z = z;
+			char *z = ret->z;
 			if (*p == 'Z' || *p == 'z') {
 				*z++ = 'Z';
 				p++;

--- a/toml.c
+++ b/toml.c
@@ -1681,8 +1681,7 @@ int toml_value_timestamp(toml_unparsed_t src_, toml_timestamp_t *ret) {
 
 		if (*p) { /// parse and copy Z
 			ret->kind = 'd';
-			char *z = malloc(10);
-			ret->z = z;
+			char *z = ret->z;
 			if (*p == 'Z' || *p == 'z') {
 				*z++ = 'Z';
 				p++;

--- a/toml.h
+++ b/toml.h
@@ -86,7 +86,7 @@ struct toml_timestamp_t {
 	char kind;
 	int year, month, day;
 	int hour, minute, second, millisec;
-	char *z;
+	char z[10];
 };
 
 // toml_parse() parses a TOML document from a string. Returns 0 on error, with

--- a/toml2json.c
+++ b/toml2json.c
@@ -65,9 +65,9 @@ static void print_raw(const char *s) {
 			millisec[0] = 0;
 		if (ts.kind == 'd' || ts.kind == 'l') {
 			printf("{\"type\": \"%s\",\"value\": \"%04d-%02d-%02dT%02d:%02d:%02d%s%s\"}",
-				(ts.z ? "datetime" : "datetime-local"),
+				(ts.kind == 'd' ? "datetime" : "datetime-local"),
 				ts.year, ts.month, ts.day, ts.hour, ts.minute, ts.second, millisec,
-				(ts.z ? ts.z : ""));
+				(ts.kind == 'd' ? ts.z : ""));
 		} else if (ts.kind == 'D') {
 			printf("{\"type\": \"date-local\",\"value\": \"%04d-%02d-%02d\"}",
 				ts.year, ts.month, ts.day);


### PR DESCRIPTION
This fixes issues #2:
- Remove overlapping `sl` member in `toml_value_t`.
- Fix allocation of `z` member in `toml_timestamp_t`.