### PR TITLE
Fix char* overriding int Issue in toml_value_t

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@
 *.so
 *.a
 *.gch
+*.exe
 /toml2json
+/toml-c-test
 /libtoml.so.1.0
 /example/array
 /example/table

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,8 @@ libtoml.so.1.0: ${OBJS}
 
 ${PROG}: ${LIB}
 
+toml-c-test: ${LIB}
+
 install: all
 	install -d ${DESTDIR}${PREFIX}/include ${DESTDIR}${PREFIX}/lib ${DESTDIR}${PREFIX}/lib/pkgconfig
 	install toml.h   ${DESTDIR}${PREFIX}/include
@@ -42,8 +44,11 @@ install: all
 	install ${SOLIB} ${DESTDIR}${PREFIX}/lib
 	sed 's!%%PREFIX%%!${PREFIX}!' ${PCFILE} >${DESTDIR}${PREFIX}/lib/pkgconfig/${PCFILE}
 
-check: ${PROG}
+check: ${PROG} toml-c-test
 	@./test.bash
+	@echo
+	@./toml-c-test
+
 
 clean:
-	rm -f *.o ${PROG} ${LIB} ${SOLIB}
+	rm -f *.o ${PROG} toml-c-test ${LIB} ${SOLIB}

--- a/header/toml-c.h
+++ b/header/toml-c.h
@@ -70,8 +70,10 @@ struct toml_value_t {
 	bool ok; // Was this value present?
 	union {
 		toml_timestamp_t *ts; // datetime; must be freed after use.
-		char             *s;  // string value; must be freed after use
-		int              sl;  // string length, excluding NULL.
+		struct {
+			char         *s;  // string value; must be freed after use
+			int          sl;  // string length, excluding NULL.
+		};
 		bool             b;   // bool value
 		int64_t          i;   // int value
 		double           d;   // double value
@@ -162,7 +164,7 @@ static char *STRDUP(const char *s) {
 
 // some old platforms define strndup macro -- drop it.
 #undef strndup
-#define strndup(x) error - forbiden - use STRNDUP instead
+#define strndup(x) error - forbidden - use STRNDUP instead
 static char *STRNDUP(const char *s, size_t n) {
 	size_t len = strnlen(s, n);
 	char *p = malloc(len + 1);

--- a/toml-c-test.c
+++ b/toml-c-test.c
@@ -1,0 +1,39 @@
+#include <stdlib.h>
+#include <string.h>
+#include "toml.h"
+
+int main() {
+       char errbuf[200];
+       toml_table_t* tbl = toml_parse("str = 'xxx'", errbuf, sizeof(errbuf));
+       if (!tbl) {
+               fprintf(stderr, "ERROR: %s\n", errbuf);
+               return 1;
+       }
+
+       int fail = 0;
+
+       // Unknown value
+       toml_value_t unknown = toml_table_string(tbl, "unknown");
+       if (unknown.ok) {
+               fprintf(stderr, "toml-c-test: unknown.ok set\n");
+               fail = 1;
+       }
+
+       toml_value_t str = toml_table_string(tbl, "str");
+       if (!str.ok) {
+               fprintf(stderr, "toml-c-test: str.ok not set\n");
+               fail = 1;
+       }
+       if (!strcmp(str.u.s, "hello world")) {
+               fprintf(stderr, "toml-c-test: str.u.s wrong value: %s\n", str.u.s);
+               fail = 1;
+       }
+       if (str.u.sl != 3) {
+               fprintf(stderr, "toml-c-test: str.u.sl wrong value: %d\n", str.u.sl);
+               fail = 1;
+       }
+
+       if (!fail)
+               printf("toml-c-test: okay\n");
+       return fail;
+}

--- a/toml.h
+++ b/toml.h
@@ -67,8 +67,10 @@ struct toml_value_t {
 	bool ok; // Was this value present?
 	union {
 		toml_timestamp_t *ts; // datetime; must be freed after use.
-		char             *s;  // string value; must be freed after use
-		int              sl;  // string length, excluding NULL.
+		struct {
+			char         *s;  // string value; must be freed after use
+			int          sl;  // string length, excluding NULL.
+		};
 		bool             b;   // bool value
 		int64_t          i;   // int value
 		double           d;   // double value


### PR DESCRIPTION
Fix issues: #2 
Wraps `char* s` and `int sl` in an anonymous struct within the union for two benefits:
- Enables accessing related fields together as a logical unit.
- Prevents accidental overwrites where s could clobber sl during union access.