### PR TITLE
chore: Ignore debug symbols on Mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.gcda
 *.gcno
 *.gcov
+*.dSYM
 /toml2json
 /toml-c-test
 /libtoml.so.1.0


### PR DESCRIPTION
A tiny PR to ignore debug symbols when building on Mac.