### PR TITLE
fix: Resolved clang bool conversion warning

### DIFF
--- a/toml.c
+++ b/toml.c
@@ -697,7 +697,7 @@ static int valtype(const char* val) {
 	toml_timestamp_t ts;
 	if (*val == '\'' || *val == '"')
 		return 's';
-	if (toml_value_bool(val, false) == 0)
+	if (toml_value_bool(val, 0) == 0)
 		return 'b';
 	if (toml_value_int(val, 0) == 0)
 		return 'i';


### PR DESCRIPTION
Please consider the CI test fixups PR first, or this and other PRs won't pass tests:
https://github.com/arp242/toml-c/pull/13

Mechanically, this change resolves a clang warning:
`initialization of pointer of type 'bool *' to null from a constant boolean expression [-Wbool-conversion]`

But I feel it also corrects the way this code reads -- using a bool literal gives an inaccurate sense of what the parameter does.

[Also, hi! -- hopefully this PR is structured in a way which is useful to you, please let me know if I can make them more helpful]