### PR TITLE
fix: Get CI tests running with current toml-test args

### DIFF
--- a/test.bash
+++ b/test.bash
@@ -58,4 +58,4 @@ if ! command -v "$tt" >/dev/null; then
 	exit 1
 fi
 
-"$tt" -toml="$toml" -skip-must-err ${skip[@]} "$@" -- "$decoder"
+"$tt" test -toml="$toml" -skip-must-err ${skip[@]} "$@" -decoder "$decoder"


### PR DESCRIPTION
It appears the arg format of toml-test has drifted since the CI tests were set up for this repo. I needed to make some tweaks to get them working.